### PR TITLE
[SDPA-4511] Added fix for grant feed metatag field create issue.

### DIFF
--- a/tide_grant.install
+++ b/tide_grant.install
@@ -8,7 +8,6 @@
 use Drupal\Component\Utility\Random;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\field\Entity\FieldConfig;
-use Drupal\Core\Config\FileStorage;
 use Drupal\user\Entity\User;
 use Drupal\workflows\Entity\Workflow;
 use Drupal\node\Entity\Node;

--- a/tide_grant.install
+++ b/tide_grant.install
@@ -222,12 +222,15 @@ function tide_grant_update_8011() {
 function tide_grant_update_8012() {
   // Adding the field from config install.
   $metaTags = 'field.field.node.grant.field_metatags';
-  $config_path = drupal_get_path('module', 'tide_grant') . '/config/install';
-  $source = new FileStorage($config_path);
+  module_load_include('inc', 'tide_core', 'includes/helpers');
+  $config_location = [drupal_get_path('module', 'tide_grant') . '/config/install'];
+  // Check if field already exported to config/sync.
+  $config_read = _tide_read_config($metaTags, $config_location, TRUE);
+
   // Obtain the storage manager for field instances.
   // Create a new field instance from the yaml configuration and save.
   \Drupal::entityManager()->getStorage('field_config')
-    ->create($source->read($metaTags))
+    ->create($config_read)
     ->save();
 
   // Adding the field to display form.


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4511

### Issue
After the field metatag gets exported by the automation tool, it adds uuid to the field. So when the update hook runs it creates a new one from the hook. Which causes problems during import and deletes the field and creates again. Because of this, all the values that get added to the metatag field during the update hook gets lost.

### Change
Added `_tide_read_config($metaTags, $config_location, TRUE);` method to check if the exported field is in config/sync. It if does then it will take that field config and create it again, so the uuid doesn't change. 