### PR TITLE
[SDPAP-6327] Added value for nodes department agency field.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "dev-feature/SRM-436_metadata_reroll_patch",
+        "dpc-sdp/tide_core": "dev-feature/SRM-436_metadata_reroll_patch as 3.1.8",
         "dpc-sdp/tide_media": "^3.0.0",
         "dpc-sdp/tide_webform": "^3.0.0",
         "drupal/migrate_cron": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "^3.0.0",
+        "dpc-sdp/tide_core": "dev-feature/SRM-436_metadata_reroll_patch",
         "dpc-sdp/tide_media": "^3.0.0",
         "dpc-sdp/tide_webform": "^3.0.0",
         "drupal/migrate_cron": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "dev-feature/SRM-436_metadata_reroll_patch as 3.1.8",
+        "dpc-sdp/tide_core": "^3.0.0",
         "dpc-sdp/tide_media": "^3.0.0",
         "dpc-sdp/tide_webform": "^3.0.0",
         "drupal/migrate_cron": "^1.2",

--- a/tide_grant.module
+++ b/tide_grant.module
@@ -217,6 +217,13 @@ function tide_grant_webform_submission_presave($submission) {
     // Set Grant Author user as node author.
     if ($user = user_load_by_name('Grant Author')) {
       $node->setOwnerId($user->id());
+      // It needs to set this mandatory field to create Jira ticket.
+      if ($node->hasField('field_department_agency') && $user->get('field_department_agency')->first()) {
+        $user_dept = $user->get('field_department_agency')->first()->getValue()['target_id'];
+        if ($user_dept) {
+          $node->set('field_department_agency', ['target_id' => $user_dept]);
+        }
+      }
     }
 
     $node->save();


### PR DESCRIPTION
### JIRA
https://digital-engagement.atlassian.net/browse/SDPAP-6327

### Issue
Whenever it tries to create the JIRA ticket, it tries to find the department field from the node and grant submission doesn't populate the field currently. 

### Changes
Updated the hook in tide_grant, so that whenever it creates the grant node on webform submission, it will fill up the department agency field in the node by checking the field value from the "Grant Author"

Test PR - 
FE - https://app.pr-945.vic-gov-au.sdp2.sdp.vic.gov.au/submit-your-grant
BE - https://nginx-php.pr-1410.content-vic.sdp2.sdp.vic.gov.au/
