### PR TITLE
[SDPAP-8093] Removed migrate cron module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ This module defines all the fields, paragraph types and block types used in Gran
 * [Tide Core](https://github.com/dpc-sdp/tide_core)
 * [Tide Media](https://github.com/dpc-sdp/tide_media)
 * [Tide Webform](https://github.com/dpc-sdp/tide_webform)
-* [Migrate Cron](https://www.drupal.org/project/migrate_cron)
 * [Migrate Plus](https://www.drupal.org/project/migrate_plus)
 * [Migrate Tools](https://www.drupal.org/project/migrate_tools)
 * [Range](https://www.drupal.org/project/range)

--- a/config/install/node.type.grant.yml
+++ b/config/install/node.type.grant.yml
@@ -3,14 +3,11 @@ status: true
 dependencies:
   module:
     - menu_ui
-    - wysiwyg_template
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
-  wysiwyg_template:
-    default_template: ''
 name: Grant
 type: grant
 description: 'Use Grant content type for grant content.'

--- a/config/optional/migrate_cron.settings.yml
+++ b/config/optional/migrate_cron.settings.yml
@@ -1,2 +1,0 @@
-grants_feed_importer_cron: 0
-grants_feed_importer_interval: '86400'

--- a/tide_grant.info.yml
+++ b/tide_grant.info.yml
@@ -9,7 +9,6 @@ dependencies:
   - dpc-sdp:tide_webform
   - drupal:datetime_range
   - drupal:menu_ui
-  - drupal:migrate_cron
   - drupal:migrate_plus
   - drupal:migrate_tools
   - drupal:range
@@ -61,7 +60,6 @@ config_devel:
     - field.storage.node.field_node_on_going
     - field.storage.node.field_node_phone
     - field.storage.node.field_overview_title
-    - migrate_cron.settings
     - migrate_plus.migration_group.default
     - tide_grant.settings
     - webform.webform.tide_grant_submission

--- a/tide_grant.install
+++ b/tide_grant.install
@@ -5,14 +5,14 @@
  * Tide Grant module install file..
  */
 
-use Drupal\Component\Utility\Random;
-use Drupal\Core\Entity\Entity\EntityFormDisplay;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\field\Entity\FieldConfig;
-use Drupal\user\Entity\Role;
-use Drupal\user\Entity\User;
-use Drupal\workflows\Entity\Workflow;
-use Drupal\node\Entity\Node;
+ use Drupal\Component\Utility\Random;
+ use Drupal\Core\Entity\Entity\EntityFormDisplay;
+ use Drupal\Core\Session\AccountInterface;
+ use Drupal\field\Entity\FieldConfig;
+ use Drupal\node\Entity\Node;
+ use Drupal\user\Entity\Role;
+ use Drupal\user\Entity\User;
+ use Drupal\workflows\Entity\Workflow;
 
 /**
  * Implements hook_install().

--- a/tide_grant.install
+++ b/tide_grant.install
@@ -5,14 +5,14 @@
  * Tide Grant module install file..
  */
 
- use Drupal\Component\Utility\Random;
- use Drupal\Core\Entity\Entity\EntityFormDisplay;
- use Drupal\Core\Session\AccountInterface;
- use Drupal\field\Entity\FieldConfig;
- use Drupal\node\Entity\Node;
- use Drupal\user\Entity\Role;
- use Drupal\user\Entity\User;
- use Drupal\workflows\Entity\Workflow;
+use Drupal\Component\Utility\Random;
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\node\Entity\Node;
+use Drupal\user\Entity\Role;
+use Drupal\user\Entity\User;
+use Drupal\workflows\Entity\Workflow;
 
 /**
  * Implements hook_install().

--- a/tide_grant.install
+++ b/tide_grant.install
@@ -716,3 +716,20 @@ function tide_grant_update_8016() {
     $display_config->save();
   }
 }
+
+/**
+ * Remove deprecated modules before d10 upgrade.
+ */
+function tide_grant_update_8017() {
+  // Check if module is both installed and enabled.
+  if (\Drupal::moduleHandler()->moduleExists('migrate_cron')) {
+    // If exists, uninstall module.
+    \Drupal::service('module_installer')->uninstall(['migrate_cron']);
+  }
+  $config_factory = \Drupal::configFactory();
+  // Delete the related config.
+  $config = $config_factory->getEditable('migrate_cron.settings.yml');
+  if ($config) {
+    $config->delete();
+  }
+}

--- a/tide_grant.module
+++ b/tide_grant.module
@@ -5,9 +5,9 @@
  * Tide Grant module functionality.
  */
 
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\Entity\Node;
-use Drupal\Component\Utility\UrlHelper;
 use Drupal\node\NodeInterface;
 
 /**

--- a/tide_grant.module
+++ b/tide_grant.module
@@ -262,7 +262,7 @@ function tide_grant_node_insert(NodeInterface $node) {
       $node->save();
     }
     if (\Drupal::moduleHandler()->moduleExists('simple_sitemap')) {
-      $generator = \Drupal::service('simple_sitemap.generator');
+      $generator = \Drupal::service('simple_sitemap.entity_manager');
       $settings = [
         'index' => FALSE,
         'priority' => 0.5,


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SDPAP-8093

### Issue
Migrate cron not in use for any purpose in the SDP projects. Also this module is not actively maintained anymore and not compatible with Drupal 10. So removing this will reduce a lot of maintenance issues when we upgrade SDP projects to Drupal 10.

###
1. Removed migrate cron and update hook to run it for all exisiting projects.
2. Updated deprecated code