### PR TITLE
Lock migrate_plus to 6.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "dpc-sdp/tide_core": "^4.0.0",
         "dpc-sdp/tide_media": "^4.0.0",
         "dpc-sdp/tide_webform": "^4.0.0",
-        "drupal/migrate_plus": "^6.0",
+        "drupal/migrate_plus": "6.0.2",
         "drupal/migrate_tools": "^6.0",
         "drupal/range": "^1.5"
     },


### PR DESCRIPTION
### Issue
migrate_plus 6.0.3 and 6.0.4 introduced an issue that breaks the JSON parser plugin. We will continue using version 6.0.2 until the issue is fixed.

more details see:
https://www.drupal.org/project/migrate_plus/issues/3462520
https://www.drupal.org/project/migrate_plus/issues/3465782


### Todo/Thoughts
Sometimes, we may lock a package to address certain issues, but eventually, we will still need to upgrade it. To avoid forgetting about the locked package, we likely need a reminder to check if it needs to be unlocked?

https://github.com/Ocramius/PackageVersions maybe useful?  
